### PR TITLE
feat: add system-assigned identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,10 @@ resource "azurerm_app_service" "main" {
 
   app_settings = "${merge(var.app_settings, local.app_settings)}"
 
+  identity {
+    type = "SystemAssigned"
+  }
+
   tags = "${var.tags}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,8 @@ output "possible_outbound_ips" {
 
   description = "A list of possible outbound IP addresses for the App Service. Superset of outbound_ips."
 }
+
+output "principal_id" {
+  value       = "${azurerm_app_service.main.identity.0.principal_id}"
+  description = "The principal ID for the system-assigned identity associated with the App Service."
+}


### PR DESCRIPTION
Use a managed identity for the App Service