### PR TITLE
feat: add `storage_mounts` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,16 @@ module "web_app_container" {
 | `docker_registry_username` | `string` | The container registry username. |
 | `docker_registry_url` | `string` | The container registry url. Default: `https://index.docker.io` |
 | `docker_registry_password` | `string` | The container registry password. |
+| `storage_mounts` | `list` | List of storage mounts for the web app. |
 | `tags` | `map` | A mapping of tags to assign to the web app. |
+
+The `storage_mounts` object must have the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The identifier of the storage mount. |
+| `type` | `string` | The type of storage. Possible values are `AzureBlob` and `AzureFiles`. |
+| `account_name` | `string` | The name of the storage account. |
+| `share_name` | `string` | The name of the file share or container. |
+| `access_key` | `string` | The access key for the storage account. |
+| `mount_path` | `string` | The path to mount the storage within the web app. |

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,19 @@ resource "azurerm_app_service" "main" {
     type = "SystemAssigned"
   }
 
+  dynamic "storage_account" {
+    for_each = var.storage_mounts
+
+    content {
+      name         = storage_account.value.name
+      type         = storage_account.value.type
+      account_name = storage_account.value.account_name
+      share_name   = storage_account.value.share_name
+      access_key   = storage_account.value.access_key
+      mount_path   = storage_account.value.mount_path
+    }
+  }
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,19 @@ variable "docker_registry_password" {
   description = "The container registry password."
 }
 
+variable "storage_mounts" {
+  type = list(object({
+    name         = string
+    type         = string
+    account_name = string
+    share_name   = string
+    access_key   = string
+    mount_path   = string
+  }))
+  default     = []
+  description = "List of storage mounts."
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
Supports mounting Azure Blobs and Azure Files into the Web App

**Note:** Because this PR uses features not yet available in a stable release of the AzureRM provider for Terrform, this should be merged into to `alpha` branch so that we create a pre-release.

cc @sandves @steinpetersen-in 