### PR TITLE
 feat: add `plan` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,8 @@ module "web_app_container" {
 | `command` | `string` | A command to be run on the container. |
 | `app_settings` | `map` | Set app settings. These are avilable as environment variables at runtime. |
 | `secure_app_settings` | `map` | Set sensitive app settings. Uses Key Vault references as values for app settings. |
-| `app_service_plan_id` | `string` | The ID of an existing app service plan to use for the web app. Either this or `sku` should be specified. |
+| `plan` | `map` | A map of app service plan properties. |
 | `key_vault_id` | `string` | The ID of an existing Key Vault. Required if `secure_app_settings` is set. |
-| `sku` | `string` | The SKU of an app service plan to create for the web app. The options are: `Basic_B1`, `Basic_B2`, `Basic_B3`, `Standard_S1`, `Standard_S2`, `Standard_S3`, `PremiumV2_P1v2`, `PremiumV2_P2v2`, and `PremiumV2_P3v2`. Default: `Basic_B1`. |
 | `always_on` | `bool` | Either `true` to ensure the web app gets loaded all the time, or `false` to to unload after being idle. |
 | `https_only` | `bool` | Redirect all traffic made to the web app using HTTP to HTTPS. Default: `true`. |
 | `ftps_state` | `string` | Set the FTPS state value the web app. The options are: `AllAllowed`, `Disabled` and `FtpsOnly`. Default: `Disabled`. |
@@ -237,3 +236,11 @@ module "web_app_container" {
 | `docker_registry_url` | `string` | The container registry url. Default: `https://index.docker.io` |
 | `docker_registry_password` | `string` | The container registry password. |
 | `tags` | `map` | A mapping of tags to assign to the web app. |
+
+The `plan` object accepts the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | The ID of an existing app service plan. |
+| `name` | `string` | The name of a new app service plan. |
+| `sku` | `string` | The SKU size of a new app service plan. The options are: `B1` (Basic Small), `B2` (Basic Medium), `B3` (Basic Large), `S1` (Standard Small), `S2` (Standard Medium), `S3` (Standard Large), `P1v2` (PremiumV2 Small), `P2v2` (PremiumV2 Medium), `P3v2` (PremiumV2 Large). Default: `B1` (Free). |

--- a/README.md
+++ b/README.md
@@ -243,4 +243,4 @@ The `plan` object accepts the following keys:
 | --- | --- | --- |
 | `id` | `string` | The ID of an existing app service plan. |
 | `name` | `string` | The name of a new app service plan. |
-| `sku` | `string` | The SKU size of a new app service plan. The options are: `B1` (Basic Small), `B2` (Basic Medium), `B3` (Basic Large), `S1` (Standard Small), `S2` (Standard Medium), `S3` (Standard Large), `P1v2` (PremiumV2 Small), `P2v2` (PremiumV2 Medium), `P3v2` (PremiumV2 Large). Default: `B1` (Free). |
+| `sku` | `string` | The SKU size of a new app service plan. The options are: `B1` (Basic Small), `B2` (Basic Medium), `B3` (Basic Large), `S1` (Standard Small), `S2` (Standard Medium), `S3` (Standard Large), `P1v2` (PremiumV2 Small), `P2v2` (PremiumV2 Medium), `P3v2` (PremiumV2 Large). Default: `B1`. |

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,8 @@ resource "azurerm_app_service" "main" {
   resource_group_name = data.azurerm_resource_group.main.name
   app_service_plan_id = local.plan_id
 
+  client_affinity_enabled = false
+
   https_only = var.https_only
 
   site_config {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ locals {
     "DOCKER_REGISTRY_SERVER_URL"          = var.docker_registry_url
     "DOCKER_REGISTRY_SERVER_PASSWORD"     = var.docker_registry_password
   }
-  app_service_plan_id = coalesce(var.app_service_plan_id, azurerm_app_service_plan.main[0].id)
 
   container_type   = upper(var.container_type)
   container_config = base64encode(var.container_config)
@@ -39,6 +38,34 @@ locals {
     for secret in azurerm_key_vault_secret.main :
     replace(secret.name, "-", "_") => format("@Microsoft.KeyVault(SecretUri=%s)", secret.id)
   }
+
+  default_plan_name = format("%s-plan", var.name)
+
+  plan = merge({
+    id   = ""
+    name = ""
+    sku  = "B1"
+  }, var.plan)
+
+  plan_id = coalesce(local.plan.id, azurerm_app_service_plan.main[0].id)
+
+  sku_tier_sizes = {
+    "Basic"     = ["B1", "B2", "B3"]
+    "Standard"  = ["S1", "S2", "S3"]
+    "Premium"   = ["P1", "P2", "P3"]
+    "PremiumV2" = ["P1v2", "P2v2", "P3v2"]
+  }
+
+  flattened_skus = flatten([
+    for tier, sizes in local.sku_tier_sizes : [
+      for size in sizes : {
+        tier = tier
+        size = size
+      }
+    ]
+  ])
+
+  sku_tiers = { for sku in local.flattened_skus : sku.size => sku.tier }
 }
 
 data "azurerm_resource_group" "main" {
@@ -46,16 +73,16 @@ data "azurerm_resource_group" "main" {
 }
 
 resource "azurerm_app_service_plan" "main" {
-  count               = var.app_service_plan_id == "" ? 1 : 0
-  name                = "${var.name}-plan"
+  count               = local.plan.id == "" ? 1 : 0
+  name                = coalesce(local.plan.name, local.default_plan_name)
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
   kind                = "linux"
   reserved            = true
 
   sku {
-    tier = split("_", var.sku)[0]
-    size = split("_", var.sku)[1]
+    tier = local.sku_tiers[local.plan.sku]
+    size = local.plan.sku
   }
 
   tags = var.tags
@@ -65,7 +92,7 @@ resource "azurerm_app_service" "main" {
   name                = var.name
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
-  app_service_plan_id = local.app_service_plan_id
+  app_service_plan_id = local.plan_id
 
   https_only = var.https_only
 

--- a/variables.tf
+++ b/variables.tf
@@ -74,12 +74,6 @@ variable "key_vault_id" {
   description = "The ID of an existing Key Vault. Required if `secure_app_settings` is set."
 }
 
-variable "sku" {
-  type        = string
-  default     = "Basic_B1"
-  description = "The SKU of an app service plan to create for the web app."
-}
-
 variable "always_on" {
   type        = bool
   default     = true
@@ -126,6 +120,12 @@ variable "docker_registry_password" {
   type        = string
   default     = ""
   description = "The container registry password."
+}
+
+variable "plan" {
+  type        = map(string)
+  default     = {}
+  description = "A map of app service plan properties."
 }
 
 variable "tags" {


### PR DESCRIPTION
- Adds `plan` argument for setting app service plan options (and removes the `sku` and `app_service_plan` arguments, as they should be set within `plan` argument now).
- Turns off Affinity Cookie