### PR TITLE
feat: add `storage_mounts` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ module "web_app_container" {
 | `docker_registry_username` | `string` | The container registry username. |
 | `docker_registry_url` | `string` | The container registry url. Default: `https://index.docker.io` |
 | `docker_registry_password` | `string` | The container registry password. |
+| `storage_mounts` | `list` | List of storage mounts for the web app. |
 | `tags` | `map` | A mapping of tags to assign to the web app. |
 
 The `plan` object accepts the following keys:
@@ -238,7 +239,7 @@ The `plan` object accepts the following keys:
 | `name` | `string` | The name of a new app service plan. |
 | `sku_size` | `string` | The SKU size of a new app service plan. The options are: `F1`, `D1`, `B1`, `B2`, `B3`, `S1`, `S2`, `S3`, `P1v2`, `P2v2`, `P3v2`. Default: `F1`. |
 
-List of SKU sizes: 
+The `sku_size` parameter can be one of the following:
 
 | Size | Tier | Description |
 | --- | --- | --- |
@@ -248,4 +249,12 @@ List of SKU sizes:
 | `S1`, `S2`, `S3` | Standard | Small, Medium, Large |
 | `P1v2`, `P2v2`, `P3v2` | PremiumV2 | Small, Medium, Large |
 
-Read more about [App Service plans](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans).
+The `storage_mounts` object accepts the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The identifier of the storage mount. |
+| `account_name` | `string` | The name of the storage account. |
+| `share_name` | `string` | The name of the file share.  |
+| `container_name` | `string` | The name of the blob container. Either this or `share_name` should be specified, but not both. |
+| `mount_path` | `string` | The path to mount the storage within the web app. |

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,20 @@ resource "azurerm_app_service" "main" {
     type = "SystemAssigned"
   }
 
+  dynamic "storage_account" {
+    for_each = local.storage_mounts
+    iterator = s
+
+    content {
+      name         = s.value.name
+      type         = s.value.share_name != "" ? "AzureFiles" : "AzureBlob"
+      account_name = s.value.account_name
+      share_name   = s.value.share_name != "" ? s.value.share_name : s.value.container_name
+      access_key   = s.value.access_key
+      mount_path   = s.value.mount_path
+    }
+  }
+
   tags = var.tags
 
   depends_on = [azurerm_key_vault_secret.main]

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,12 @@ variable "plan" {
   description = "A map of app service plan properties."
 }
 
+variable "storage_mounts" {
+  type        = any
+  default     = []
+  description = "List of storage mounts."
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}
@@ -203,4 +209,15 @@ locals {
   always_on = local.is_shared ? false : true
 
   use_32_bit_worker_process = local.is_shared ? true : false
+
+  storage_mounts = [
+    for s in var.storage_mounts : merge({
+      name           = ""
+      account_name   = ""
+      access_key     = ""
+      share_name     = ""
+      container_name = ""
+      mount_path     = ""
+    }, s)
+  ]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,7 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    azurerm = ">= 1.32"
+  }
 }


### PR DESCRIPTION
Adds support for storage mounts

**Note:** This requires `v1.32` of the AzureRM provider for Terraform, which has not yet released. Will merge this once it has been released.