### PR TITLE
feat: support for user-assigned identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ module "web_app_container" {
 | `ftps_state` | `string` | Set the FTPS state value the web app. The options are: `AllAllowed`, `Disabled` and `FtpsOnly`. Default: `Disabled`. |
 | `ip_restrictions` | `list` | A list of IP addresses in CIDR format specifying Access Restrictions. |
 | `custom_hostnames` | `list` | List of custom hostnames to use for the web app. |
+| `identity` | `object` | Managed service identity properties. This should be `identity` object. |
 | `docker_registry_username` | `string` | The container registry username. |
 | `docker_registry_url` | `string` | The container registry url. Default: `https://index.docker.io` |
 | `docker_registry_password` | `string` | The container registry password. |
@@ -249,3 +250,10 @@ List of SKU sizes:
 | `P1v2`, `P2v2`, `P3v2` | PremiumV2 | Small, Medium, Large |
 
 Read more about [App Service plans](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans).
+
+The `identity` object accepts the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `enabled` | `bool` | Whether managed service identity is enabled for the web app. Default: `true`. |
+| `ids` | `list` | List of user managed identity IDs. |

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,11 @@ resource "azurerm_app_service" "main" {
   app_settings = merge(var.app_settings, local.secure_app_settings, local.app_settings)
 
   identity {
-    type = "SystemAssigned"
+    type = (local.identity.enabled ?
+      (local.identity.ids != null ? "SystemAssigned, UserAssigned" : "SystemAssigned") :
+      "None"
+    )
+    identity_ids = local.identity.ids
   }
 
   tags = var.tags

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,8 +30,10 @@ output "plan" {
   description = "A mapping of App Service plan properties."
 }
 
-output "principal_id" {
-  value       = azurerm_app_service.main.identity[0].principal_id
-  description = "The principal ID for the system-assigned identity associated with the App Service."
+output "identity" {
+  value = {
+    principal_id = azurerm_app_service.main.identity[0].principal_id
+    ids          = azurerm_app_service.main.identity[0].identity_ids
+  }
+  description = "A mapping og identity properties for the web app."
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,12 @@ variable "plan" {
   description = "A map of app service plan properties."
 }
 
+variable "identity" {
+  type        = any
+  default     = {}
+  description = "Managed service identity properties."
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}
@@ -203,4 +209,9 @@ locals {
   always_on = local.is_shared ? false : true
 
   use_32_bit_worker_process = local.is_shared ? true : false
+
+  identity = merge({
+    enabled = true
+    ids     = null
+  }, var.identity)
 }


### PR DESCRIPTION
**Note:** This requires `v1.32` of the AzureRM provider for Terraform, which has not yet released. Will merge this once it has been released.